### PR TITLE
Update link to Kotlin library

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ similar functionality. As such, each of the types are suffixed with "Tuple".
 Type aliases exist without the Tuple suffixes from version 1.2.1 onwards.
 
 There is a new replacement of the Kotlin library available
-[here](https://github.com/notquiteamonad/date-time-kt).
+[here](https://github.com/notquiteamonad/datetimekt).
 
 ##### Serde Support
 


### PR DESCRIPTION
I'm not sure if this is the intended target, but https://github.com/notquiteamonad/datetimekt is a dead link (or possibly private?)